### PR TITLE
Add middleware to api routes

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Manogi\Tiptap\Controllers\FilesController;
+use Manogi\Tiptap\Controllers\ImagesController;
+
+Route::post('file', FilesController::class.'@store');
+Route::post('image', ImagesController::class.'@store');

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,0 @@
-<?php
-
-use Illuminate\Support\Facades\Route;
-
-Route::post('/nova-tiptap/api/image', 'Manogi\Tiptap\Controllers\ImagesController@store');
-Route::post('/nova-tiptap/api/file', 'Manogi\Tiptap\Controllers\FilesController@store');

--- a/src/FieldServiceProvider.php
+++ b/src/FieldServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Manogi\Tiptap;
 
+use Illuminate\Support\Facades\Route;
 use Laravel\Nova\Nova;
 use Laravel\Nova\Events\ServingNova;
 use Illuminate\Support\ServiceProvider;
@@ -15,18 +16,36 @@ class FieldServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->loadRoutesFrom(__DIR__.'/../routes/web.php');
+        $this->app->booted(function () {
+            $this->routes();
+        });
 
         Nova::provideToScript([
             'novaTiptap' => [
                 'translations' => $this->translations()
             ]
         ]);
-        
+
         Nova::serving(function (ServingNova $event) {
             Nova::script('tiptap', __DIR__.'/../dist/js/field.js');
             Nova::style('tiptap', __DIR__.'/../dist/css/field.css');
         });
+    }
+
+    /**
+     * Register routes.
+     *
+     * @return void
+     */
+    protected function routes()
+    {
+        if ($this->app->routesAreCached()) {
+            return;
+        }
+
+        Route::middleware(['nova'])
+            ->prefix('nova-tiptap/api')
+            ->group(__DIR__.'/../routes/api.php');
     }
 
     /**


### PR DESCRIPTION
Currently there is no protection and anyone can add files calling the `POST /nova-tiptap/api/files`.
This PR fixes this security issue, adding a middleware to protect API routes.

I also changed how routes are registered by following what is generated using the `nova:resource-tool` command.