### PR TITLE
Moved provideToScript to Nova serving

### DIFF
--- a/src/FieldServiceProvider.php
+++ b/src/FieldServiceProvider.php
@@ -20,13 +20,13 @@ class FieldServiceProvider extends ServiceProvider
             $this->routes();
         });
 
-        Nova::provideToScript([
-            'novaTiptap' => [
-                'translations' => $this->translations()
-            ]
-        ]);
-
         Nova::serving(function (ServingNova $event) {
+            Nova::provideToScript([
+                'novaTiptap' => [
+                    'translations' => $this->translations()
+                ]
+            ]);
+
             Nova::script('tiptap', __DIR__.'/../dist/js/field.js');
             Nova::style('tiptap', __DIR__.'/../dist/css/field.css');
         });


### PR DESCRIPTION
After updating the package to 2.x my custom auth guards didn't register. According to [Nova documentation](https://nova.laravel.com/docs/3.0/customization/frontend.html#global-variables) the `Nova::provideToScript` method should be called within `Nova::serving`. It fixes the problem.