### PR TITLE
Remove margin-top

### DIFF
--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -9,7 +9,7 @@
             <div
                 class="
                     w-full sticky overflow-break top-3 z-10
-                    bg-40 mt-8 rounded-lg
+                    bg-40 rounded-lg
                 "
             >
                 <template>


### PR DESCRIPTION
Allows field to align with label as with the rest of the fields in Nova